### PR TITLE
feat: EAS attestation integration for repository activity

### DIFF
--- a/scripts/attest-historical.ts
+++ b/scripts/attest-historical.ts
@@ -25,6 +25,10 @@ import { createEASService } from "~/server/services/eas";
 
 const db = new PrismaClient();
 
+// Determine chain based on environment (matches EAS service logic)
+const isMainnet = process.env.EAS_USE_MAINNET === "true";
+const chainName = isMainnet ? "optimism-mainnet" : "optimism-sepolia";
+
 // Parse CLI arguments
 const args = process.argv.slice(2);
 const dryRun = args.includes("--dry-run");
@@ -152,6 +156,7 @@ async function main() {
   console.log(
     `Period: ${event.startDate.toISOString().split("T")[0]} to ${event.endDate.toISOString().split("T")[0]}`
   );
+  console.log(`Network: ${chainName} (${isMainnet ? "MAINNET" : "TESTNET"})`);
 
   // Query repositories with residency metrics for this event
   const residencyMetrics = await db.repositoryResidencyMetrics.findMany({
@@ -265,7 +270,7 @@ async function main() {
             uid: attestation.uid,
             repositoryId: repo.id,
             schemaId: process.env.EAS_SCHEMA_UID ?? "",
-            chain: "optimism",
+            chain: chainName,
             data: {
               projectId: repo.project.id,
               repositoryId: repo.id,


### PR DESCRIPTION
## Summary
- Adds EAS (Ethereum Attestation Service) integration for creating on-chain attestations of repository activity
- Historical attestation script for retroactive weekly attestations
- UI displays attestations in project Impact tab with correct EAS explorer links
- Fixes chain name storage to properly distinguish testnet vs mainnet attestations

## Test plan
- [x] Run historical attestations on testnet
- [ ] Delete testnet attestations from production DB
- [ ] Run historical attestations on mainnet with `EAS_USE_MAINNET=true`
- [ ] Verify attestation links point to correct EAS explorer (mainnet vs sepolia)