### PR TITLE
fix: update floor-applicant test after intentional validation removal

### DIFF
--- a/tests/integration/schedule.test.ts
+++ b/tests/integration/schedule.test.ts
@@ -208,9 +208,11 @@ describe("Schedule Router", () => {
     });
   });
 
-  // ── Test 5: Speaker must be floor applicant when added by floor lead ──
+  // ── Test 5: Floor leads may add any participant, applicant or not ─────
+  // Floor-applicant validation was intentionally removed in f71fd69
+  // ("feat: remove speaker validation for session participants").
   describe("floor applicant validation", () => {
-    it("floor lead cannot add speakers who haven't applied for their floor", async () => {
+    it("floor lead can add speakers who haven't applied for their floor", async () => {
       const db = getTestDb();
       const floorLead = await createTestUser(
         { role: "user", name: "Strict Lead" },
@@ -241,22 +243,23 @@ describe("Schedule Router", () => {
       const startTime = new Date(event.startDate.getTime() + 2 * 60 * 60 * 1000);
       const endTime = new Date(startTime.getTime() + 60 * 60 * 1000);
 
-      try {
-        await caller.schedule.createSession({
-          eventId: event.id,
-          title: "Invalid Speaker Session",
-          startTime,
-          endTime,
-          venueId: venue.id,
-          linkedSpeakers: [{ userId: nonApplicant.id, role: "Speaker" }],
-          isPublished: true,
-        });
-        expect.unreachable("Should have thrown FORBIDDEN");
-      } catch (error) {
-        expect(error).toBeInstanceOf(TRPCError);
-        expect((error as TRPCError).code).toBe("FORBIDDEN");
-        expect((error as TRPCError).message).toContain("floor");
-      }
+      const result = await caller.schedule.createSession({
+        eventId: event.id,
+        title: "Open Speaker Session",
+        startTime,
+        endTime,
+        venueId: venue.id,
+        linkedSpeakers: [{ userId: nonApplicant.id, role: "Speaker" }],
+        isPublished: true,
+      });
+
+      expect(result.id).toBeDefined();
+
+      const sessionSpeakers = await db.sessionSpeaker.findMany({
+        where: { sessionId: result.id },
+      });
+      expect(sessionSpeakers).toHaveLength(1);
+      expect(sessionSpeakers[0]?.userId).toBe(nonApplicant.id);
     });
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config";
+
+// Root config so a bare `vitest` / `bun run test` runs the same suites as CI
+// (unit + integration), each with its own environment and aliases, instead of
+// collecting every *.test/*.spec file with no config. Component/form tests run
+// via `bun run test:form*` (vitest.config.form.ts) and Playwright e2e specs
+// via `bun run test:e2e`.
+export default defineConfig({
+  test: {
+    projects: [
+      { extends: "./vitest.config.unit.ts", test: { name: "unit" } },
+      { extends: "./vitest.config.integration.ts", test: { name: "integration" } },
+    ],
+  },
+});


### PR DESCRIPTION
## Summary
- The Test Suite workflow has been red on main because `tests/integration/schedule.test.ts` ("floor lead cannot add speakers who haven't applied for their floor") still expected a `FORBIDDEN` error from `validateSpeakersAreFloorApplicants`, but that validation was intentionally removed in f71fd69 ("feat: remove speaker validation for session participants"). The product behavior is the source of truth, so the test now codifies it: floor leads can link any participant to their sessions, applicant or not.
- Adds a root `vitest.config.ts` with `unit` + `integration` projects so a bare `bun run test` runs the same suites as CI, each with its proper environment and aliases. Previously it collected Playwright `.spec.ts` files and jsdom component tests with no config, producing spurious alias/`document is not defined` failures.

## Test plan
- `bun run test:integration` — 33/33 pass (including the updated test)
- `bun run test:unit` — 41/41 pass
- `bun run test` (new root config) — 74/74 pass
- `bun run check` — 0 errors

Note: 4 component test files (performance, form-integration, scroll-behavior, DynamicApplicationForm) fail even under their own `vitest.config.form.ts`; they're pre-existing breakage, excluded from the default run (as they already were from `test:form`), and tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)