### PR TITLE
fix(security): enforce authorization on admin, CRM, and role APIs

### DIFF
--- a/src/app/api/test-email/route.ts
+++ b/src/app/api/test-email/route.ts
@@ -1,8 +1,15 @@
 import { NextResponse } from "next/server";
 import { sendEmail } from "~/lib/email";
 import { env } from "~/env";
+import { auth } from "~/server/auth";
 
 export async function GET() {
+  // Restrict this diagnostic email-send endpoint to authenticated admins.
+  const session = await auth();
+  if (session?.user?.role !== "admin") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   // Get current email configuration
   const emailConfig = {
     mode: env.EMAIL_MODE,

--- a/src/app/profiles/ProfilesClient.tsx
+++ b/src/app/profiles/ProfilesClient.tsx
@@ -373,7 +373,7 @@ export function ProfilesClient() {
                           Array.isArray(member.adminLabels) &&
                           member.adminLabels.length > 0 && (
                             <Group gap={4} mb="xs">
-                              {(member.adminLabels as string[])
+                              {member.adminLabels
                                 .slice(0, 3)
                                 .map((label) => (
                                   <Badge

--- a/src/server/api/routers/coinGecko.ts
+++ b/src/server/api/routers/coinGecko.ts
@@ -1,5 +1,9 @@
 import { z } from "zod";
-import { createTRPCRouter, publicProcedure } from "~/server/api/trpc";
+import {
+  createTRPCRouter,
+  publicProcedure,
+  adminOrStaffProcedure,
+} from "~/server/api/trpc";
 
 // TypeScript types based on CoinGecko API response
 const RoiSchema = z
@@ -40,7 +44,7 @@ const CoinGeckoApiResponseSchema = z.object({
 });
 
 export const coinGeckoRouter = createTRPCRouter({
-  fetchAndStoreCategoryCoins: publicProcedure
+  fetchAndStoreCategoryCoins: adminOrStaffProcedure
     .input(
       z.object({
         category: z.string(),
@@ -253,7 +257,7 @@ export const coinGeckoRouter = createTRPCRouter({
       return coins;
     }),
 
-  linkSponsorToCategory: publicProcedure
+  linkSponsorToCategory: adminOrStaffProcedure
     .input(
       z.object({
         sponsorId: z.string(),

--- a/src/server/api/routers/contact.ts
+++ b/src/server/api/routers/contact.ts
@@ -24,7 +24,7 @@ interface TelegramContactsResult {
 import {
   createTRPCRouter,
   protectedProcedure,
-  publicProcedure,
+  adminOrStaffProcedure,
 } from "~/server/api/trpc";
 import { convertHtmlToText } from "~/utils/htmlToText";
 
@@ -559,18 +559,17 @@ async function upsertContact(
 }
 
 export const contactRouter = createTRPCRouter({
-  getContacts: publicProcedure.query(async ({ ctx }) => {
+  getContacts: adminOrStaffProcedure.query(async ({ ctx }) => {
     const contacts = await ctx.db.contact.findMany({
       include: {
         sponsor: true,
       },
     });
-    console.log(contacts);
 
     return contacts ?? null;
   }),
 
-  getContact: publicProcedure
+  getContact: adminOrStaffProcedure
     .input(z.object({ id: z.string() }))
     .query(async ({ ctx, input }) => {
       const contact = await ctx.db.contact.findUnique({
@@ -586,7 +585,7 @@ export const contactRouter = createTRPCRouter({
       return contact;
     }),
 
-  getContactCommunications: publicProcedure
+  getContactCommunications: adminOrStaffProcedure
     .input(
       z.object({
         contactId: z.string(),
@@ -655,7 +654,7 @@ export const contactRouter = createTRPCRouter({
       return communications;
     }),
 
-  assignContactToSponsor: publicProcedure
+  assignContactToSponsor: adminOrStaffProcedure
     .input(
       z.object({
         contactId: z.string(),
@@ -673,7 +672,7 @@ export const contactRouter = createTRPCRouter({
       return contact;
     }),
 
-  removeContactFromSponsor: publicProcedure
+  removeContactFromSponsor: adminOrStaffProcedure
     .input(
       z.object({
         contactId: z.string(),

--- a/src/server/api/routers/event.ts
+++ b/src/server/api/routers/event.ts
@@ -6,6 +6,7 @@ import {
   createTRPCRouter,
   publicProcedure,
   protectedProcedure,
+  adminOrStaffProcedure,
 } from "~/server/api/trpc";
 import { getEventSlugService } from "~/server/services/eventSlugService";
 
@@ -514,7 +515,7 @@ export const eventRouter = createTRPCRouter({
     return events;
   }),
 
-  addSponsorToEvent: publicProcedure
+  addSponsorToEvent: adminOrStaffProcedure
     .input(
       z.object({
         eventId: z.string(),
@@ -549,7 +550,7 @@ export const eventRouter = createTRPCRouter({
       return eventSponsor;
     }),
 
-  updateSponsorQualified: publicProcedure
+  updateSponsorQualified: adminOrStaffProcedure
     .input(
       z.object({
         eventId: z.string(),
@@ -580,14 +581,14 @@ export const eventRouter = createTRPCRouter({
       return eventSponsor;
     }),
 
-  syncEventsToNotion: publicProcedure
+  syncEventsToNotion: adminOrStaffProcedure
     .input(z.object({ events: z.array(EventDataSchema) }))
     .mutation(async ({ input }) => {
       const result = await syncEventsToNotion(input.events);
       return result;
     }),
 
-  syncUsersToNotion: publicProcedure
+  syncUsersToNotion: adminOrStaffProcedure
     .input(z.object({ events: z.array(EventDataSchema) }))
     .mutation(async ({ input }) => {
       const result = await syncUsersToNotion(input.events);

--- a/src/server/api/routers/invitation.ts
+++ b/src/server/api/routers/invitation.ts
@@ -609,15 +609,15 @@ export const invitationRouter = createTRPCRouter({
           gt: new Date(),
         },
       },
-        include: {
-          event: true,
-          role: true,
-        },
-        orderBy: { createdAt: "desc" },
-      });
+      include: {
+        event: true,
+        role: true,
+      },
+      orderBy: { createdAt: "desc" },
+    });
 
-      return invitations;
-    }),
+    return invitations;
+  }),
 
   // Accept invitation by token
   acceptByToken: publicProcedure

--- a/src/server/api/routers/invitation.ts
+++ b/src/server/api/routers/invitation.ts
@@ -593,18 +593,22 @@ export const invitationRouter = createTRPCRouter({
       return invitations;
     }),
 
-  // Get pending invitations for a specific email
-  getPendingByEmail: publicProcedure
-    .input(z.object({ email: z.string().email() }))
-    .query(async ({ ctx, input }) => {
-      const invitations = await ctx.db.invitation.findMany({
-        where: {
-          email: { equals: input.email.toLowerCase(), mode: "insensitive" },
-          status: "PENDING",
-          expiresAt: {
-            gt: new Date(),
-          },
+  // Get pending invitations for the currently authenticated user's email.
+  // Scoped to the session email to avoid leaking whether an arbitrary address
+  // has invitations (account/email enumeration).
+  getPendingByEmail: protectedProcedure.query(async ({ ctx }) => {
+    const email = ctx.session.user.email;
+    if (!email) {
+      return [];
+    }
+    const invitations = await ctx.db.invitation.findMany({
+      where: {
+        email: { equals: email.toLowerCase(), mode: "insensitive" },
+        status: "PENDING",
+        expiresAt: {
+          gt: new Date(),
         },
+      },
         include: {
           event: true,
           role: true,

--- a/src/server/api/routers/profile.ts
+++ b/src/server/api/routers/profile.ts
@@ -641,17 +641,25 @@ export const profileRouter = createTRPCRouter({
         nextCursor = nextItem!.id;
       }
 
-      // Strip sensitive admin fields for non-admin callers
-      const members = isAdmin
-        ? users
-        : users.map(
-            ({
-              adminLabels: _al,
-              adminNotes: _an,
-              adminWorkExperience: _aw,
-              ...rest
-            }) => rest,
-          );
+      // Never expose the password hash through the member directory — strip it
+      // for every caller. Account fields (email, emailVerified) and internal
+      // admin fields are restricted to admin/staff callers only; for everyone
+      // else they are nulled out (keeping a consistent response shape).
+      const members = users.map((user) => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars -- drop password hash from the response
+        const { password: _pw, ...rest } = user;
+        if (isAdmin) return rest;
+        return {
+          ...rest,
+          email: null,
+          emailVerified: null,
+          adminNotes: null,
+          adminLabels: [] as string[],
+          adminWorkExperience: null,
+          adminUpdatedBy: null,
+          adminUpdatedAt: null,
+        };
+      });
 
       return {
         members,

--- a/src/server/api/routers/role.ts
+++ b/src/server/api/routers/role.ts
@@ -8,6 +8,10 @@ import {
   adminProcedure,
   adminOrStaffProcedure,
 } from "~/server/api/trpc";
+import {
+  assertAdminOrEventFloorOwner,
+  isAdminOrStaff,
+} from "~/server/api/utils/scheduleAuth";
 
 export const roleRouter = createTRPCRouter({
   // Get all global roles
@@ -217,7 +221,7 @@ export const roleRouter = createTRPCRouter({
   }),
 
   // Get all users with their event roles and applications
-  getAllUsersWithEventRoles: adminProcedure
+  getAllUsersWithEventRoles: protectedProcedure
     .input(
       z.object({
         search: z.string().optional(),
@@ -226,6 +230,19 @@ export const roleRouter = createTRPCRouter({
       }),
     )
     .query(async ({ ctx, input }) => {
+      // Admin/staff may list users globally; floor leads only when scoped to
+      // an event they own a venue in (mirrors application.getEventApplications,
+      // which authorizes the same speaker-management page).
+      if (input.eventId) {
+        await assertAdminOrEventFloorOwner(
+          ctx.db,
+          ctx.session.user.id,
+          ctx.session.user.role,
+          input.eventId,
+        );
+      } else if (!isAdminOrStaff(ctx.session.user.role)) {
+        throw new TRPCError({ code: "FORBIDDEN" });
+      }
 
       const users = await ctx.db.user.findMany({
         where: {
@@ -291,6 +308,16 @@ export const roleRouter = createTRPCRouter({
           { name: "asc" },
         ],
       });
+
+      // Floor leads don't get internal admin fields.
+      if (!isAdminOrStaff(ctx.session.user.role)) {
+        return users.map((user) => ({
+          ...user,
+          adminNotes: null,
+          adminLabels: [] as string[],
+          adminWorkExperience: null,
+        }));
+      }
 
       return users;
     }),

--- a/src/server/api/routers/role.ts
+++ b/src/server/api/routers/role.ts
@@ -5,6 +5,8 @@ import {
   createTRPCRouter,
   publicProcedure,
   protectedProcedure,
+  adminProcedure,
+  adminOrStaffProcedure,
 } from "~/server/api/trpc";
 
 export const roleRouter = createTRPCRouter({
@@ -29,7 +31,7 @@ export const roleRouter = createTRPCRouter({
   }),
 
   // Get a user's global roles
-  getUserGlobalRoles: publicProcedure
+  getUserGlobalRoles: adminProcedure
     .input(z.object({ userId: z.string() }))
     .query(async ({ ctx, input }) => {
       const userRoles = await ctx.db.userGlobalRole.findMany({
@@ -97,7 +99,7 @@ export const roleRouter = createTRPCRouter({
     }),
 
   // Create a new global role (admin only)
-  createGlobalRole: protectedProcedure
+  createGlobalRole: adminProcedure
     .input(
       z.object({
         name: z.string().min(1),
@@ -106,7 +108,6 @@ export const roleRouter = createTRPCRouter({
       }),
     )
     .mutation(async ({ ctx, input }) => {
-      // TODO: Add admin check here once we implement it
       const role = await ctx.db.globalRole.create({
         data: {
           name: input.name,
@@ -118,7 +119,7 @@ export const roleRouter = createTRPCRouter({
     }),
 
   // Assign role to user (admin only)
-  assignGlobalRole: protectedProcedure
+  assignGlobalRole: adminProcedure
     .input(
       z.object({
         userId: z.string(),
@@ -126,7 +127,6 @@ export const roleRouter = createTRPCRouter({
       }),
     )
     .mutation(async ({ ctx, input }) => {
-      // TODO: Add admin check here once we implement it
 
       // Check if assignment already exists
       const existing = await ctx.db.userGlobalRole.findUnique({
@@ -168,7 +168,7 @@ export const roleRouter = createTRPCRouter({
     }),
 
   // Remove role from user (admin only)
-  removeGlobalRole: protectedProcedure
+  removeGlobalRole: adminProcedure
     .input(
       z.object({
         userId: z.string(),
@@ -176,7 +176,6 @@ export const roleRouter = createTRPCRouter({
       }),
     )
     .mutation(async ({ ctx, input }) => {
-      // TODO: Add admin check here once we implement it
 
       const deleted = await ctx.db.userGlobalRole.deleteMany({
         where: {
@@ -196,8 +195,7 @@ export const roleRouter = createTRPCRouter({
     }),
 
   // Get all users with their global roles (admin only)
-  getUsersWithRoles: protectedProcedure.query(async ({ ctx }) => {
-    // TODO: Add admin check here once we implement it
+  getUsersWithRoles: adminProcedure.query(async ({ ctx }) => {
 
     const users = await ctx.db.user.findMany({
       select: {
@@ -219,7 +217,7 @@ export const roleRouter = createTRPCRouter({
   }),
 
   // Get all users with their event roles and applications
-  getAllUsersWithEventRoles: protectedProcedure
+  getAllUsersWithEventRoles: adminProcedure
     .input(
       z.object({
         search: z.string().optional(),
@@ -228,7 +226,6 @@ export const roleRouter = createTRPCRouter({
       }),
     )
     .query(async ({ ctx, input }) => {
-      // TODO: Add admin check here once we implement it
 
       const users = await ctx.db.user.findMany({
         where: {
@@ -299,7 +296,7 @@ export const roleRouter = createTRPCRouter({
     }),
 
   // Assign event role to existing user
-  assignEventRole: protectedProcedure
+  assignEventRole: adminOrStaffProcedure
     .input(
       z.object({
         userId: z.string(),
@@ -308,7 +305,6 @@ export const roleRouter = createTRPCRouter({
       }),
     )
     .mutation(async ({ ctx, input }) => {
-      // TODO: Add admin check here once we implement it
 
       // Check if assignment already exists
       const existing = await ctx.db.userRole.findUnique({
@@ -377,7 +373,7 @@ export const roleRouter = createTRPCRouter({
     }),
 
   // Remove event role from user
-  removeEventRole: protectedProcedure
+  removeEventRole: adminOrStaffProcedure
     .input(
       z.object({
         userId: z.string(),
@@ -386,7 +382,6 @@ export const roleRouter = createTRPCRouter({
       }),
     )
     .mutation(async ({ ctx, input }) => {
-      // TODO: Add admin check here once we implement it
 
       const deleted = await ctx.db.userRole.deleteMany({
         where: {
@@ -407,7 +402,7 @@ export const roleRouter = createTRPCRouter({
     }),
 
   // Update user's global role (admin -> staff -> user)
-  updateUserGlobalRole: protectedProcedure
+  updateUserGlobalRole: adminProcedure
     .input(
       z.object({
         userId: z.string(),
@@ -415,7 +410,6 @@ export const roleRouter = createTRPCRouter({
       }),
     )
     .mutation(async ({ ctx, input }) => {
-      // TODO: Add admin check here once we implement it
 
       const user = await ctx.db.user.update({
         where: { id: input.userId },
@@ -434,10 +428,9 @@ export const roleRouter = createTRPCRouter({
     }),
 
   // Get user details with all roles and applications
-  getUserDetails: protectedProcedure
+  getUserDetails: adminProcedure
     .input(z.object({ userId: z.string() }))
     .query(async ({ ctx, input }) => {
-      // TODO: Add admin check here once we implement it
 
       const user = await ctx.db.user.findUnique({
         where: { id: input.userId },
@@ -499,8 +492,7 @@ export const roleRouter = createTRPCRouter({
     }),
 
   // Get user statistics
-  getUserStats: protectedProcedure.query(async ({ ctx }) => {
-    // TODO: Add admin check here once we implement it
+  getUserStats: adminProcedure.query(async ({ ctx }) => {
 
     const [totalUsers, adminCount, staffCount, usersWithRoles] =
       await Promise.all([
@@ -621,8 +613,7 @@ export const roleRouter = createTRPCRouter({
   }),
 
   // Ensure mentor role exists
-  ensureMentorRole: protectedProcedure.mutation(async ({ ctx }) => {
-    // TODO: Add admin check here once we implement it
+  ensureMentorRole: adminOrStaffProcedure.mutation(async ({ ctx }) => {
 
     const mentorRole = await ctx.db.role.findFirst({
       where: { name: "mentor" },
@@ -641,7 +632,7 @@ export const roleRouter = createTRPCRouter({
   }),
 
   // Ensure speaker role exists
-  ensureSpeakerRole: protectedProcedure.mutation(async ({ ctx }) => {
+  ensureSpeakerRole: adminOrStaffProcedure.mutation(async ({ ctx }) => {
     const speakerRole = await ctx.db.role.findFirst({
       where: { name: "speaker" },
     });

--- a/src/server/api/routers/sponsor.ts
+++ b/src/server/api/routers/sponsor.ts
@@ -4,6 +4,7 @@ import {
   createTRPCRouter,
   publicProcedure,
   protectedProcedure,
+  adminOrStaffProcedure,
 } from "~/server/api/trpc";
 
 export const sponsorRouter = createTRPCRouter({
@@ -34,7 +35,7 @@ export const sponsorRouter = createTRPCRouter({
       return sponsor;
     }),
 
-  getSponsors: publicProcedure.query(async ({ ctx }) => {
+  getSponsors: adminOrStaffProcedure.query(async ({ ctx }) => {
     const sponsors = await ctx.db.sponsor.findMany({
       include: {
         contacts: true,
@@ -49,7 +50,7 @@ export const sponsorRouter = createTRPCRouter({
     return sponsors;
   }),
 
-  getSponsor: publicProcedure
+  getSponsor: adminOrStaffProcedure
     .input(z.object({ id: z.string() }))
     .query(async ({ ctx, input }) => {
       const sponsor = await ctx.db.sponsor.findUnique({
@@ -66,7 +67,7 @@ export const sponsorRouter = createTRPCRouter({
       return sponsor;
     }),
 
-  getSponsorCommunications: publicProcedure
+  getSponsorCommunications: adminOrStaffProcedure
     .input(
       z.object({
         sponsorId: z.string(),
@@ -148,7 +149,7 @@ export const sponsorRouter = createTRPCRouter({
     }),
 
   // Get sponsor residency data including visit requests and deliverables
-  getSponsorResidencyData: publicProcedure
+  getSponsorResidencyData: protectedProcedure
     .input(z.object({ eventSponsorId: z.string() }))
     .query(async ({ ctx, input }) => {
       const eventSponsor = await ctx.db.eventSponsor.findUnique({
@@ -168,7 +169,7 @@ export const sponsorRouter = createTRPCRouter({
     }),
 
   // Create a visit request
-  createVisitRequest: publicProcedure
+  createVisitRequest: protectedProcedure
     .input(
       z.object({
         eventSponsorId: z.string(),
@@ -202,7 +203,7 @@ export const sponsorRouter = createTRPCRouter({
     }),
 
   // Update visit request status
-  updateVisitRequestStatus: publicProcedure
+  updateVisitRequestStatus: protectedProcedure
     .input(
       z.object({
         visitRequestId: z.string(),
@@ -230,7 +231,7 @@ export const sponsorRouter = createTRPCRouter({
     }),
 
   // Create deliverable
-  createDeliverable: publicProcedure
+  createDeliverable: protectedProcedure
     .input(
       z.object({
         eventSponsorId: z.string(),
@@ -256,7 +257,7 @@ export const sponsorRouter = createTRPCRouter({
     }),
 
   // Update deliverable status
-  updateDeliverableStatus: publicProcedure
+  updateDeliverableStatus: protectedProcedure
     .input(
       z.object({
         deliverableId: z.string(),
@@ -289,7 +290,7 @@ export const sponsorRouter = createTRPCRouter({
     }),
 
   // Bulk create default deliverables for a sponsor
-  createDefaultDeliverables: publicProcedure
+  createDefaultDeliverables: protectedProcedure
     .input(z.object({ eventSponsorId: z.string() }))
     .mutation(async ({ ctx, input }) => {
       const defaultDeliverables = [

--- a/src/server/api/trpc.ts
+++ b/src/server/api/trpc.ts
@@ -211,8 +211,18 @@ export const protectedProcedure = t.procedure
  * Use for any query or mutation that manages roles/permissions or exposes
  * platform-wide administrative data.
  */
-export const adminProcedure = protectedProcedure.use(({ ctx, next }) => {
+export const adminProcedure = protectedProcedure.use(async ({ ctx, next }) => {
+  // The JWT role claim is only set at sign-in, so check it first as a cheap
+  // filter but verify against the DB before granting access — otherwise a
+  // demoted user keeps admin power for the lifetime of their token.
   if (ctx.session.user.role !== "admin") {
+    throw new TRPCError({ code: "FORBIDDEN" });
+  }
+  const dbUser = await ctx.db.user.findUnique({
+    where: { id: ctx.session.user.id },
+    select: { role: true },
+  });
+  if (dbUser?.role !== "admin") {
     throw new TRPCError({ code: "FORBIDDEN" });
   }
   return next({ ctx });
@@ -225,10 +235,21 @@ export const adminProcedure = protectedProcedure.use(({ ctx, next }) => {
  * `staff` role. Use for privileged operational data (e.g. CRM, communications)
  * that staff need but the general public and ordinary members must not see.
  */
-export const adminOrStaffProcedure = protectedProcedure.use(({ ctx, next }) => {
-  const role = ctx.session.user.role;
-  if (role !== "admin" && role !== "staff") {
-    throw new TRPCError({ code: "FORBIDDEN" });
-  }
-  return next({ ctx });
-});
+export const adminOrStaffProcedure = protectedProcedure.use(
+  async ({ ctx, next }) => {
+    // Same as adminProcedure: the JWT role claim is only set at sign-in, so
+    // verify the current role against the DB before granting access.
+    const role = ctx.session.user.role;
+    if (role !== "admin" && role !== "staff") {
+      throw new TRPCError({ code: "FORBIDDEN" });
+    }
+    const dbUser = await ctx.db.user.findUnique({
+      where: { id: ctx.session.user.id },
+      select: { role: true },
+    });
+    if (dbUser?.role !== "admin" && dbUser?.role !== "staff") {
+      throw new TRPCError({ code: "FORBIDDEN" });
+    }
+    return next({ ctx });
+  },
+);

--- a/src/server/api/trpc.ts
+++ b/src/server/api/trpc.ts
@@ -203,3 +203,32 @@ export const protectedProcedure = t.procedure
       },
     });
   });
+
+/**
+ * Admin-only procedure
+ *
+ * Requires an authenticated session whose user has the global `admin` role.
+ * Use for any query or mutation that manages roles/permissions or exposes
+ * platform-wide administrative data.
+ */
+export const adminProcedure = protectedProcedure.use(({ ctx, next }) => {
+  if (ctx.session.user.role !== "admin") {
+    throw new TRPCError({ code: "FORBIDDEN" });
+  }
+  return next({ ctx });
+});
+
+/**
+ * Admin-or-staff procedure
+ *
+ * Requires an authenticated session whose user has the global `admin` or
+ * `staff` role. Use for privileged operational data (e.g. CRM, communications)
+ * that staff need but the general public and ordinary members must not see.
+ */
+export const adminOrStaffProcedure = protectedProcedure.use(({ ctx, next }) => {
+  const role = ctx.session.user.role;
+  if (role !== "admin" && role !== "staff") {
+    throw new TRPCError({ code: "FORBIDDEN" });
+  }
+  return next({ ctx });
+});


### PR DESCRIPTION
## Summary

Fixes several **critical** broken-access-control and data-exposure vulnerabilities surfaced through a responsible-disclosure report. All three reported issues were validated against the code as real and exploitable, plus a handful of related issues found during the audit.

**Root cause:** the tRPC layer had only `publicProcedure` and `protectedProcedure` — no admin tier — so authorization was left to inline checks that were either never written (`role.ts` had 11 `// TODO: Add admin check` markers) or skipped by putting privileged endpoints on `publicProcedure`.

## Vulnerabilities fixed

| Severity | Issue | Fix |
|---|---|---|
| Critical | **Privilege escalation** — any authenticated user could call `role.updateUserGlobalRole` and set their own `role` to `admin` | Gated all 11 unguarded role/user procedures with `adminProcedure` / `adminOrStaffProcedure` |
| Critical | **Member directory leaked emails + bcrypt password hashes** to anonymous callers (`profile.getAllMembers` returned all User columns) | Never return `password`; null email/admin fields for non-staff |
| Critical | **Public CRM/sponsor APIs** exposed contact PII and full communication threads, plus allowed unauthenticated writes | Require staff/auth on reads and mutations; removed `console.log(contacts)` |
| Medium | `event.syncUsersToNotion` + siblings and `coinGecko` writes were public | Require admin/staff |
| Medium | `invitation.getPendingByEmail` allowed email enumeration | Scoped to the caller's own session email |
| Low | `/api/test-email` was an unauthenticated email-send trigger | Require an authenticated admin |

## New auth primitives

Added `adminProcedure` and `adminOrStaffProcedure` to `src/server/api/trpc.ts` so authorization is enforced by procedure type going forward.

## Validation

- `bun run check` (ESLint + `tsc --noEmit`) passes clean.
- No unrelated changes; the one-line `ProfilesClient.tsx` edit removes a type assertion made redundant by the `getAllMembers` change.

## Follow-ups (not in this PR)

- **Rotate credentials:** bcrypt hashes were exposed — recommend forcing a password reset for email/password users (OAuth users unaffected).
- **Residual IDOR:** the sponsor-portal procedures set to `protectedProcedure` (`getSponsorResidencyData`, visit/deliverable mutations) still allow any logged-in user to act by `eventSponsorId`. Closing this needs an ownership check tied to the sponsor-access model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Post-review updates (2026-08-26)

An adversarial review pass on this branch surfaced two issues, both fixed in follow-up commits:

- **DB-verified roles:** `adminProcedure` / `adminOrStaffProcedure` now re-check the caller's role against the database rather than trusting the JWT claim alone. The JWT `role` claim is set only at sign-in, so without this a demoted (or reverted-attacker) session would have kept admin power for the remaining token lifetime.
- **Floor-lead regression avoided:** `role.getAllUsersWithEventRoles` was gated admin-only, which would have broken the current-speakers list on the staff/floor-lead speaker page (`/events/[eventId]/speakers`). It now mirrors `application.getEventApplications`: admin/staff always; floor leads only when scoped to their own event, with internal admin fields stripped.
- Merged `main` (PR #43 had shipped overlapping inline staff checks for `contact.ts` / `syncUsersToNotion`); the inline checks are kept as defense-in-depth beneath the procedure gates.

## Additional follow-ups

- **Audit `User.role`:** since any user could self-promote before this fix, audit existing `admin`/`staff` role values for unauthorized grants.
- `profile.getAllMembers` sanitizes by denylist; converting to an explicit allowlist would prevent future `User` columns from leaking by default.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Strengthened access controls across administrative, staff, sponsor, contact, event, role, and cryptocurrency management tools.
  * Restricted diagnostic email testing and sensitive account, profile, role, and sponsor information to authorized users.
  * Users now see only the information permitted by their role.
  * Invitation lookups are limited to the authenticated user’s own email.
  * Added consistent authorization checks for administrative and staff actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->